### PR TITLE
Allow all settings to be set in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,14 @@ Checkout this [sample plunker](https://embed.plnkr.co/VFwGvAO6MhV06IDTLk5W/)
 * **preserveSize**:_boolean_ - will not scale the resulting image to the croppedWidth/croppedHeight and will output the exact crop size from original
 * **fileType**:_string_ - if defined all images will be converted to desired format. sample: cropperSample.fileType = 'image/jpeg'
 * **compressRatio**:_number_ (default: 1.0) - default compress ratio
-* **dynamicSizing**: (default: false) - if true then the cropper becomes responsive - might introduce performance issues on resize;
-* **cropperClass**: string - set class on canvas element;
-* **croppingClass**: string - appends class to cropper when image is set (#142);
+* **dynamicSizing**: (default: false) - if true then the cropper becomes responsive - might introduce performance issues on resize
+* **cropperClass**: string - set class on canvas element
+* **croppingClass**: string - appends class to cropper when image is set (#142)
 * **resampleFn**: Function(canvas) - function used to resample the cropped image (#136); - see example #3 from runtime sample app
 * **cropOnResize**:_boolean_ (default: true) - if true the cropper will create a new cropped Image object immediately when the crop area is resized
-* **markerSizeMultiplier**:_number_ (default: 1) - A variable that control the corner markers' size
+* **markerSizeMultiplier**:_number_ (default: 1) - A variable that controls the corner markers' size
 * **showCenterMarker**:_boolean_ (default: true) - if true, the drag center marker is visible
+* **keepAspect**:_boolean_ (default: true) - if true, the aspect ratio of `width` and `height` of the crop window is retained during resizing
 
 ## Customizing Image cropper
 
@@ -227,7 +228,7 @@ Fix for #92 - IOS crop issue
 * introduced rounded cropper: cropperSettings.rounded = true. Making keep aspect = false will throw an error on rounded cropper. (Issue #14)
 * cropper takes into consideration source image data pixels not cropper image data. (Issue #17)
 * support for minSize now have the following option: minWithRelativeToResolution. When set to false it will keep min size relative to canvas size. (Issue #21)
-* allow user to customize look and feel of the cropper:  
+* allow user to customize look and feel of the cropper:
    this.cropperSettings.cropperDrawSettings.strokeColor = 'rgba(255,255,255,1)';
   this.cropperSettings.cropperDrawSettings.strokeWidth = 2;
 

--- a/src/cropperSettings.ts
+++ b/src/cropperSettings.ts
@@ -3,6 +3,9 @@ import { CropperDrawSettings } from "./cropperDrawSettings";
 export interface ICropperSettings {
   canvasWidth?: number;
   canvasHeight?: number;
+  dynamicSizing?: boolean;
+  cropperClass?: string;
+  croppingClass?: string;
   width?: number;
   height?: number;
   minWidth?: number;
@@ -10,15 +13,20 @@ export interface ICropperSettings {
   minWithRelativeToResolution?: boolean;
   croppedWidth?: number;
   croppedHeight?: number;
-  touchRadius?: number;
   cropperDrawSettings?: any;
+  touchRadius?: number;
   noFileInput?: boolean;
+  fileType?: string;
+  resampleFn?: Function;
+  markerSizeMultiplier?: number;
+  centerTouchRadius?: number;
+  showCenterMarker?: boolean;
   allowedFilesRegex?: RegExp;
-  rounded: boolean;
-  keepAspect: boolean;
-  preserveSize: boolean;
-  cropOnResize: boolean;
-  compressRatio: number;
+  cropOnResize?: boolean;
+  preserveSize?: boolean;
+  compressRatio?: number;
+  rounded?: boolean;
+  keepAspect?: boolean;
 }
 
 export class CropperSettings implements ICropperSettings {
@@ -60,33 +68,9 @@ export class CropperSettings implements ICropperSettings {
   private _rounded: boolean = false;
   private _keepAspect: boolean = true;
 
-  constructor(settings?: any) {
+  constructor(settings?: ICropperSettings) {
     if (typeof settings === "object") {
-      this.canvasWidth = settings.canvasWidth || this.canvasWidth;
-      this.canvasHeight = settings.canvasHeight || this.canvasHeight;
-      this.width = settings.width || this.width;
-      this.height = settings.height || this.height;
-      this.minWidth = settings.minWidth || this.minWidth;
-      this.minHeight = settings.minHeight || this.minHeight;
-      this.minWithRelativeToResolution =
-        settings.minWithRelativeToResolution ||
-        this.minWithRelativeToResolution;
-      this.croppedWidth = settings.croppedWidth || this.croppedWidth;
-      this.croppedHeight = settings.croppedHeight || this.croppedHeight;
-      this.touchRadius = settings.touchRadius || this.touchRadius;
-      this.cropperDrawSettings =
-        settings.cropperDrawSettings || this.cropperDrawSettings;
-      this.noFileInput = settings.noFileInput || this.noFileInput;
-      this.allowedFilesRegex =
-        settings.allowedFilesRegex || this.allowedFilesRegex;
-      this.rounded = settings.rounded || this.rounded;
-      this.keepAspect = settings.keepAspect || this.keepAspect;
-      this.preserveSize = settings.preserveSize || this.preserveSize;
-      this.cropOnResize = settings.cropOnResize || this.cropOnResize;
-      this.compressRatio = settings.compressRatio || this.compressRatio;
-
-      this.cropperDrawSettings =
-        settings.cropperDrawSettings || this.cropperDrawSettings;
+      Object.assign(this, settings);
     }
   }
 

--- a/src/imageCropper.ts
+++ b/src/imageCropper.ts
@@ -36,21 +36,27 @@ export class ImageCropper extends ImageCropperModel {
         this.x = x;
         this.y = y;
 
+        this.canvasHeight = cropperSettings.canvasHeight;
+        this.canvasWidth = cropperSettings.canvasWidth;
+
+        this.width = width;
         if (width === void 0) {
             this.width = 100;
         }
+        this.height = height;
         if (height === void 0) {
             this.height = 50;
         }
+        this.keepAspect = keepAspect;
         if (keepAspect === void 0) {
             this.keepAspect = true;
         }
+        this.touchRadius = touchRadius;
         if (touchRadius === void 0) {
             this.touchRadius = 20;
         }
         this.minWidth = minWidth;
         this.minHeight = minHeight;
-        this.keepAspect = false;
         this.aspectRatio = 0;
         this.currentDragTouches = [];
         this.isMouseDown = false;
@@ -75,9 +81,7 @@ export class ImageCropper extends ImageCropperModel {
         this.br.addVerticalNeighbour(this.tr);
         this.markers = [this.tl, this.tr, this.bl, this.br];
 
-
         this.center = new DragMarker(x + (width / 2), y + (height / 2), centerTouchRadius, this.cropperSettings);
-        this.keepAspect = keepAspect;
         this.aspectRatio = height / width;
         this.croppedImage = new Image();
         this.currentlyInteracting = false;


### PR DESCRIPTION
1. The `CropperSettings` constructor didn't allow boolean flags to be set to false. The value would always be set to the default value.

2. Updated type interface for constructor to include app public properties.

3. `ImageCropper` always forced `keepAspect` to false. Some properties were also left uninitialized; some appear to be set later depending on which methods are called.