### PR TITLE
Update all uses of ViewChild to not have undefined as the second argument for Angular 8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Replacing component file input:
 ```typescript
 data:any;
 
-@ViewChild('cropper', undefined)
+@ViewChild('cropper')
 cropper:ImageCropperComponent;
 
 constructor() {

--- a/projects/ngx-img-cropper/README.md
+++ b/projects/ngx-img-cropper/README.md
@@ -131,7 +131,7 @@ Replacing component file input:
 ```typescript
 data:any;
 
-@ViewChild('cropper', undefined)
+@ViewChild('cropper')
 cropper:ImageCropperComponent;
 
 constructor() {

--- a/projects/ngx-img-cropper/src/lib/image-cropper/image-cropper.component.ts
+++ b/projects/ngx-img-cropper/src/lib/image-cropper/image-cropper.component.ts
@@ -25,7 +25,7 @@ import { Exif } from './exif';
 })
 export class ImageCropperComponent
   implements AfterViewInit, OnChanges, OnDestroy {
-  @ViewChild('cropcanvas', undefined)
+  @ViewChild('cropcanvas')
   cropcanvas: ElementRef;
   @ViewChild('fileInput') fileInput: ElementRef;
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,16 +17,16 @@ export class AppComponent {
   public data2: any;
   public cropperSettings2: CropperSettings;
 
-  @ViewChild('cropper1', undefined)
+  @ViewChild('cropper1')
   public cropper1: ImageCropperComponent;
 
-  @ViewChild('cropper2', undefined)
+  @ViewChild('cropper2')
   public cropper2: ImageCropperComponent;
 
-  @ViewChild('cropper3', undefined)
+  @ViewChild('cropper3')
   public cropper3: ImageCropperComponent;
 
-  @ViewChild('cropper4', undefined)
+  @ViewChild('cropper4')
   public cropper4: ImageCropperComponent;
 
   public onChange: ($event: any) => void;


### PR DESCRIPTION
I've been attempting to get angular 8 working and it appears there is a small issue with this library. In several places where ViewChild is used, the 2nd argument passed is `undefined`. This is unnecessary in current versions of angular (maybe always? not sure), and in angular 8 it produces this error:
```
ERROR in @ViewChild options must be an object literal
```
Here is another issue where this was addressed:

https://github.com/angular/angular-cli/issues/14298#issuecomment-487390502

Angular 8 is currently in RC, so I'm not sure if this will get cleared up on there side, but making this changes does allow me to successfully build.