### PR TITLE
fix(image-cropper): fix cropping area resizing

### DIFF
--- a/projects/ngx-img-cropper/src/lib/image-cropper/image-cropper.component.html
+++ b/projects/ngx-img-cropper/src/lib/image-cropper/image-cropper.component.html
@@ -9,9 +9,6 @@
   <canvas
     #cropcanvas
     (mousedown)="onMouseDown($event)"
-    (mouseup)="onMouseUp($event)"
-    (mousemove)="onMouseMove($event)"
-    (mouseleave)="onMouseUp($event)"
     (touchmove)="onTouchMove($event)"
     (touchend)="onTouchEnd($event)"
     (touchstart)="onTouchStart($event)"


### PR DESCRIPTION
When the mouse went out of the canvas the cropping area stopped resizing.
It made it hard to move the cropping area to the border.

Closes: #43